### PR TITLE
feat(sys): impl Send for JsRef

### DIFF
--- a/chakracore-sys/src/lib.rs
+++ b/chakracore-sys/src/lib.rs
@@ -6,6 +6,7 @@ extern crate libc;
 include!(concat!(env!("OUT_DIR"), "/ffi.rs"));
 
 unsafe impl Send for JsRuntimeHandle {}
+unsafe impl Send for JsRef {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Gotta make `JsRef` `Send` as well in order to send Contexts and Values across thread boundaries.

What's concerning me a little is that there is no Chakracore docs about thread-safety, so I'm just assuming stuff at this point, but by default it ships with extra threads for GC and JIT, so I'm figuring `JsAddRef`&co need to be thread-safe or that wouldn't work? Still, would be great to get your opinion on that, and maybe we should open a question over at the Chakracore repo to get an authoritative answer to this.